### PR TITLE
Add hpcmrb to build targets

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,7 @@ end
 load "#{MRUBY_ROOT}/src/mruby_core.rake"
 load "#{MRUBY_ROOT}/mrblib/mrblib.rake"
 load "#{MRUBY_ROOT}/tools/mrbc/mrbc.rake"
+load "#{MRUBY_ROOT}/tools/hpcmrb/hpcmrb.rake"
 
 load "#{MRUBY_ROOT}/tasks/mrbgems.rake"
 load "#{MRUBY_ROOT}/tasks/libmruby.rake"

--- a/build_config.rb
+++ b/build_config.rb
@@ -55,7 +55,7 @@ MRuby::Build.new do |conf|
 
 
   # Generate binaries
-  # conf.bins = %w(mrbc)
+  conf.bins = %w(mrbc hpcmrb)
 
   # Generate mirb command
   conf.gem "#{root}/mrbgems/mruby-bin-mirb"

--- a/tasks/mruby_build.rake
+++ b/tasks/mruby_build.rake
@@ -74,7 +74,7 @@ module MRuby
         @git = Command::Git.new(self)
         @mrbc = Command::Mrbc.new(self)
 
-        @bins = %w(mrbc)
+        @bins = %w(mrbc hpcmrb)
         @gems, @libmruby = [], []
         @build_mrbtest_lib_only = false
 
@@ -101,6 +101,10 @@ module MRuby
 
     def mrbcfile
       MRuby.targets['host'].exefile("#{MRuby.targets['host'].build_dir}/bin/mrbc")
+    end
+
+    def hpcmrbfile
+      MRuby.targets['host'].exefile("#{MRuby.targets['host'].build_dir}/bin/hpcmrb")
     end
 
     def compilers

--- a/tools/hpcmrb/codegen.c
+++ b/tools/hpcmrb/codegen.c
@@ -1,7 +1,7 @@
 #include "hpcmrb.h"
 
 mrb_value
-hpc_generate_code(mrb_state *mrb, FILE *wfp, struct HIR *hir, mrbc_context *c)
+hpc_generate_code(mrb_state *mrb, FILE *wfp, HIR *hir, mrbc_context *c)
 {
   puts("hpc_generate_code: NOT IMPLEMENTED YET");
   return mrb_fixnum_value(1); /* Stub */

--- a/tools/hpcmrb/codegen.c
+++ b/tools/hpcmrb/codegen.c
@@ -1,0 +1,8 @@
+#include "hpcmrb.h"
+
+mrb_value
+hpc_generate_code(mrb_state *mrb, FILE *wfp, struct HIR *hir, mrbc_context *c)
+{
+  puts("hpc_generate_code: NOT IMPLEMENTED YET");
+  return mrb_fixnum_value(1); /* Stub */
+}

--- a/tools/hpcmrb/compile.c
+++ b/tools/hpcmrb/compile.c
@@ -1,0 +1,8 @@
+#include "hpcmrb.h"
+
+struct HIR *
+hpc_compile_file(mrb_state *mrb, FILE *rfp, mrbc_context *c)
+{
+  puts("hpc_compile_file: NOT IMPLEMENTED YET");
+  return (struct HIR*) 1; /* stub */
+}

--- a/tools/hpcmrb/compile.c
+++ b/tools/hpcmrb/compile.c
@@ -1,8 +1,8 @@
 #include "hpcmrb.h"
 
-struct HIR *
+HIR*
 hpc_compile_file(mrb_state *mrb, FILE *rfp, mrbc_context *c)
 {
   puts("hpc_compile_file: NOT IMPLEMENTED YET");
-  return (struct HIR*) 1; /* stub */
+  return (HIR*) 1; /* stub */
 }

--- a/tools/hpcmrb/hpcmrb.c
+++ b/tools/hpcmrb/hpcmrb.c
@@ -1,0 +1,252 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "mruby.h"
+#include "mruby/compile.h"
+#include "mruby/dump.h"
+#include "mruby/proc.h"
+
+#define RITEBIN_EXT ".mrb"
+#define C_EXT       ".c"
+
+void mrb_show_version(mrb_state *);
+void mrb_show_copyright(mrb_state *);
+void parser_dump(mrb_state*, struct mrb_ast_node*, int);
+void codedump_all(mrb_state*, int);
+
+struct _args {
+  FILE *rfp;
+  FILE *wfp;
+  char *filename;
+  char *initname;
+  char *ext;
+  mrb_bool check_syntax : 1;
+  mrb_bool verbose      : 1;
+  mrb_bool debug_info   : 1;
+};
+
+static void
+usage(const char *name)
+{
+  static const char *const usage_msg[] = {
+  "switches:",
+  "-c           check syntax only",
+  "-o<outfile>  place the output into <outfile>",
+  "-v           print version number, then turn on verbose mode",
+  "-g           produce debugging information",
+  "-B<symbol>   binary <symbol> output in C language format",
+  "--verbose    run at verbose mode",
+  "--version    print the version",
+  "--copyright  print the copyright",
+  NULL
+  };
+  const char *const *p = usage_msg;
+
+  printf("Usage: %s [switches] programfile\n", name);
+  while(*p)
+    printf("  %s\n", *p++);
+}
+
+static char *
+get_outfilename(mrb_state *mrb, char *infile, char *ext)
+{
+  char *outfile;
+  char *p;
+
+  outfile = (char*)mrb_malloc(mrb, strlen(infile) + strlen(ext) + 1);
+  strcpy(outfile, infile);
+  if (*ext) {
+    if ((p = strrchr(outfile, '.')) == NULL)
+      p = &outfile[strlen(outfile)];
+    strcpy(p, ext);
+  }
+
+  return outfile;
+}
+
+static int
+parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
+{
+  char *infile = NULL;
+  char *outfile = NULL;
+  char **origargv = argv;
+  int result = EXIT_SUCCESS;
+  static const struct _args args_zero = { 0 };
+
+  *args = args_zero;
+  args->ext = RITEBIN_EXT;
+
+  for (argc--,argv++; argc > 0; argc--,argv++) {
+    if (**argv == '-') {
+      if (strlen(*argv) == 1) {
+        args->filename = infile = "-";
+        args->rfp = stdin;
+        break;
+      }
+
+      switch ((*argv)[1]) {
+      case 'o':
+        if (outfile) {
+          printf("%s: An output file is already specified. (%s)\n",
+                 *origargv, outfile);
+          result = EXIT_FAILURE;
+          goto exit;
+        }
+        outfile = get_outfilename(mrb, (*argv) + 2, "");
+        break;
+      case 'B':
+        args->ext = C_EXT;
+        args->initname = (*argv) + 2;
+        if (*args->initname == '\0') {
+          printf("%s: Function name is not specified.\n", *origargv);
+          result = EXIT_FAILURE;
+          goto exit;
+        }
+        break;
+      case 'c':
+        args->check_syntax = 1;
+        break;
+      case 'v':
+        if(!args->verbose) mrb_show_version(mrb);
+        args->verbose = 1;
+        break;
+      case 'g':
+        args->debug_info = 1;
+        break;
+      case '-':
+        if (strcmp((*argv) + 2, "version") == 0) {
+          mrb_show_version(mrb);
+          exit(EXIT_SUCCESS);
+        }
+        else if (strcmp((*argv) + 2, "verbose") == 0) {
+          args->verbose = 1;
+          break;
+        }
+        else if (strcmp((*argv) + 2, "copyright") == 0) {
+          mrb_show_copyright(mrb);
+          exit(EXIT_SUCCESS);
+        }
+        result = EXIT_FAILURE;
+        goto exit;
+      default:
+        break;
+      }
+    }
+    else if (args->rfp == NULL) {
+      args->filename = infile = *argv;
+      if ((args->rfp = fopen(infile, "r")) == NULL) {
+        printf("%s: Cannot open program file. (%s)\n", *origargv, infile);
+        goto exit;
+      }
+    }
+  }
+
+  if (infile == NULL) {
+    result = EXIT_FAILURE;
+    goto exit;
+  }
+  if (!args->check_syntax) {
+    if (outfile == NULL) {
+      if (strcmp("-", infile) == 0) {
+        outfile = infile;
+      }
+      else {
+        outfile = get_outfilename(mrb, infile, args->ext);
+      }
+    }
+    if (strcmp("-", outfile) == 0) {
+      args->wfp = stdout;
+    }
+    else if ((args->wfp = fopen(outfile, "wb")) == NULL) {
+      printf("%s: Cannot open output file. (%s)\n", *origargv, outfile);
+      result = EXIT_FAILURE;
+      goto exit;
+    }
+  }
+
+exit:
+  if (outfile && infile != outfile) mrb_free(mrb, outfile);
+  return result;
+}
+
+static void
+cleanup(mrb_state *mrb, struct _args *args)
+{
+  if (args->rfp)
+    fclose(args->rfp);
+  if (args->wfp)
+    fclose(args->wfp);
+  mrb_close(mrb);
+}
+
+int
+main(int argc, char **argv)
+{
+  mrb_state *mrb = mrb_open();
+  int n = -1;
+  struct _args args;
+  mrbc_context *c;
+  mrb_value result;
+
+  puts("Oh, this is just a bytecode compiler.");
+  puts("You should implement a FAST HPC compiler.");
+  puts("Do your best!! :P");
+
+  if (mrb == NULL) {
+    fputs("Invalid mrb_state, exiting mrbc\n", stderr);
+    return EXIT_FAILURE;
+  }
+
+  n = parse_args(mrb, argc, argv, &args);
+  if (n == EXIT_FAILURE || args.rfp == NULL) {
+    cleanup(mrb, &args);
+    usage(argv[0]);
+    return n;
+  }
+
+  c = mrbc_context_new(mrb);
+  if (args.verbose)
+    c->dump_result = 1;
+  c->no_exec = 1;
+  c->filename = args.filename;
+  result = mrb_load_file_cxt(mrb, args.rfp, c);
+  if (mrb_undef_p(result) || mrb_fixnum(result) < 0) {
+    cleanup(mrb, &args);
+    return EXIT_FAILURE;
+  }
+  if (args.check_syntax) {
+    puts("Syntax OK");
+    cleanup(mrb, &args);
+    return EXIT_SUCCESS;
+  }
+  if (args.initname) {
+    n = mrb_dump_irep_cfunc(mrb, n, args.debug_info, args.wfp, args.initname);
+    if (n == MRB_DUMP_INVALID_ARGUMENT) {
+      printf("%s: Invalid C language symbol name\n", args.initname);
+      return EXIT_FAILURE;
+    }
+  }
+  else {
+    n = mrb_dump_irep_binary(mrb, n, args.debug_info, args.wfp);
+  }
+
+  cleanup(mrb, &args);
+  return EXIT_SUCCESS;
+}
+
+void
+mrb_init_mrblib(mrb_state *mrb)
+{
+}
+
+#ifndef DISABLE_GEMS
+void
+mrb_init_mrbgems(mrb_state *mrb)
+{
+}
+
+void
+mrb_final_mrbgems(mrb_state *mrb)
+{
+}
+#endif

--- a/tools/hpcmrb/hpcmrb.h
+++ b/tools/hpcmrb/hpcmrb.h
@@ -1,0 +1,24 @@
+#ifndef HPCMRB_H
+#define HPCMRB_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include "mruby.h"
+#include "mruby/compile.h"
+
+/* High-level intermediate representation. */
+struct HIR {
+};
+
+
+struct HIR *hpc_compile_file(mrb_state*, FILE*, mrbc_context*);
+mrb_value hpc_generate_code(mrb_state*, FILE*, struct HIR*, mrbc_context*);
+
+#if defined(__cplusplus)
+}  /* extern "C" { */
+#endif
+
+#endif  /* HPCMRB_H */

--- a/tools/hpcmrb/hpcmrb.h
+++ b/tools/hpcmrb/hpcmrb.h
@@ -10,12 +10,64 @@ extern "C" {
 #include "mruby/compile.h"
 
 /* High-level intermediate representation. */
-struct HIR {
+enum hir_type {
+  /* declarations */
+  HIR_GVARDECL,
+  HIR_LVARDECL,
+  HIR_PVARDECL,
+  HIR_FUNDECL,
+
+  HIR_INIT_LIST,
+
+  /* statements */
+  HIR_SEQ,
+  HIR_ASSIGN,
+  HIR_IFELSE,
+  HIR_DOALL,
+  HIR_WHILE,
+  HIR_BREAK,
+  HIR_CONTINUE,
+  HIR_RETURN,
+
+  /* expressions */
+  HIR_EMPTY,
+  HIR_LIT,
+  HIR_VAR,
+  HIR_CALL,
+  HIR_ADDRESSOF,
+
+  /* others */
+  HIR_TYPE,
 };
 
+enum hir_type_kind {
+  HTYPE_VALUE, /* corresponds to mrb_value */
+  HTYPE_SYM,   /* corresponds to mrb_sym */
 
-struct HIR *hpc_compile_file(mrb_state*, FILE*, mrbc_context*);
-mrb_value hpc_generate_code(mrb_state*, FILE*, struct HIR*, mrbc_context*);
+  HTYPE_CHAR,
+  HTYPE_INT,
+  HTYPE_FLOAT, /* NB: Its precision depends on MRB_USE_FLOAT */
+  HTYPE_STRING,
+
+  HTYPE_PTR,
+  HTYPE_ARRAY,
+  HTYPE_FUNC,
+};
+
+enum hir_var_kind {
+  HVAR_RB_GVAR, /* mruby's global variable */
+  HVAR_RB_CVAR, /* mruby's constant variable */
+  HVAR_GVAR,    /* global variable */
+  HVAR_LVAR,    /* local variable */
+};
+
+typedef struct HIR {
+  struct HIR *car, *cdr;
+  short lineno;
+} HIR;
+
+HIR *hpc_compile_file(mrb_state*, FILE*, mrbc_context*);
+mrb_value hpc_generate_code(mrb_state*, FILE*, HIR*, mrbc_context*);
 
 #if defined(__cplusplus)
 }  /* extern "C" { */

--- a/tools/hpcmrb/hpcmrb.rake
+++ b/tools/hpcmrb/hpcmrb.rake
@@ -1,0 +1,15 @@
+MRuby.each_target do
+  bin_name = 'hpcmrb'
+  current_dir = File.dirname(__FILE__).relative_path_from(Dir.pwd)
+  relative_from_root = File.dirname(__FILE__).relative_path_from(MRUBY_ROOT)
+  current_build_dir = "#{build_dir}/#{relative_from_root}"
+
+  if bins.find { |s| s.to_s == bin_name }
+    exec = exefile("#{build_dir}/bin/#{bin_name}")
+    objs = Dir.glob("#{current_dir}/*.c").map { |f| objfile(f.pathmap("#{current_build_dir}/%n")) }.flatten
+
+    file exec => objs + [libfile("#{build_dir}/lib/libmruby_core")] do |t|
+      linker.run t.name, t.prerequisites
+    end
+  end
+end


### PR DESCRIPTION
@nineties さんの計画にしたがって hpcmrb をビルドターゲットに追加しました。
個人的には名前もとくに問題ないとおもいます。

make すると bin/hpcmrb がビルドされるようになります。
いまは mrbc とまったく同じ動作をするので、 @nineties さんの今後の方針にしたがって機能を入れていきましょう。
