### PR TITLE
Refactoring lattice functions

### DIFF
--- a/tools/hpcmrb/compile.c
+++ b/tools/hpcmrb/compile.c
@@ -205,10 +205,8 @@ lat_le(mrb_state *mrb, mrb_value lat1, mrb_value lat2)
 static int
 lat_set_add(mrb_state *mrb, mrb_value lat, mrb_value val)
 {
-  if (!LAT_HAS_TYPE(mrb, lat, LAT_SET))
-    NOT_REACHABLE();
-  if (LAT_HAS_TYPE(mrb, val, LAT_SET))
-    NOT_REACHABLE();
+  hpc_assert(LAT_HAS_TYPE(mrb, lat, LAT_SET));
+  hpc_assert(!LAT_HAS_TYPE(mrb, val, LAT_SET));
   if (!LAT_P(mrb, val))
     val = mrb_obj_value(mrb_obj_class(mrb, val));
   if (lat_include(mrb, lat, val))

--- a/tools/hpcmrb/compile.c
+++ b/tools/hpcmrb/compile.c
@@ -88,11 +88,14 @@ lat_inspect(mrb_state *mrb, mrb_value lat)
 }
 
 static int
-ary_include(mrb_state *mrb, mrb_value ary[], int len, mrb_value val)
+ary_include_lat(mrb_state *mrb, mrb_value ary, mrb_value lat)
 {
   int i;
+  int len = RARRAY_LEN(ary);
+  mrb_value *ptr = RARRAY_PTR(ary);
+
   for (i = 0; i < len; i++) {
-    if (LAT_HAS_TYPE(mrb, ary[i], LAT_DYNAMIC) || lat_equal(mrb, ary[i], val))
+    if (LAT_HAS_TYPE(mrb, ptr[i], LAT_DYNAMIC) || lat_equal(mrb, ptr[i], lat))
       return TRUE;
   }
   return FALSE;
@@ -107,10 +110,7 @@ lat_include(mrb_state *mrb, mrb_value lat, mrb_value val)
     return TRUE;
   if (LAT(lat)->type != LAT_SET)
     return FALSE;
-  return ary_include(mrb,
-      RARRAY_PTR(LAT(lat)->elems), 
-      RARRAY_LEN(LAT(lat)->elems),
-      val);
+  return ary_include_lat(mrb, LAT(lat)->elems, val);
 }
 
 static int
@@ -141,7 +141,7 @@ lat_equal(mrb_state *mrb, mrb_value lat1, mrb_value lat2)
         mrb_value *ary2 = RARRAY_PTR(elems2);
         int i, len = RARRAY_LEN(elems1);
         for (i = 0; i < len; i++) {
-          if (!ary_include(mrb, ary2, len, ary1[i]))
+          if (!ary_include_lat(mrb, elems2, ary1[i]))
             return FALSE;
         }
         return TRUE;
@@ -185,7 +185,7 @@ lat_le(mrb_state *mrb, mrb_value lat1, mrb_value lat2)
         int i, len1 = RARRAY_LEN(elems1), len2 = RARRAY_LEN(elems2);
         /* NB: We assume that len is small enough */
         for (i = 0; i < len1; i++) {
-          if (!ary_include(mrb, ary2, len2, ary1[i]))
+          if (!ary_include_lat(mrb, elems2, ary1[i]))
             return FALSE;
         }
         return TRUE;
@@ -239,8 +239,8 @@ lat_set_equal2(mrb_state *mrb, mrb_value lat, mrb_value val1, mrb_value val2)
   mrb_value elems = LAT(lat)->elems;
   if (RARRAY_LEN(elems) != 2)
     return FALSE;
-  return ary_include(mrb, RARRAY_PTR(elems), RARRAY_LEN(elems), val1) &&
-         ary_include(mrb, RARRAY_PTR(elems), RARRAY_LEN(elems), val2);
+  return ary_include_lat(mrb, elems, val1) &&
+         ary_include_lat(mrb, elems, val2);
 }
 
 static int
@@ -255,9 +255,9 @@ lat_set_equal3(mrb_state *mrb, mrb_value lat, mrb_value val1, mrb_value val2,
   mrb_value elems = LAT(lat)->elems;
   if (RARRAY_LEN(elems) != 3)
     return FALSE;
-  return ary_include(mrb, RARRAY_PTR(elems), RARRAY_LEN(elems), val1) &&
-         ary_include(mrb, RARRAY_PTR(elems), RARRAY_LEN(elems), val2) &&
-         ary_include(mrb, RARRAY_PTR(elems), RARRAY_LEN(elems), val3);
+  return ary_include_lat(mrb, elems, val1) &&
+         ary_include_lat(mrb, elems, val2) &&
+         ary_include_lat(mrb, elems, val3);
 }
 
 static int
@@ -272,10 +272,10 @@ lat_set_equal4(mrb_state *mrb, mrb_value lat, mrb_value val1, mrb_value val2,
   mrb_value elems = LAT(lat)->elems;
   if (RARRAY_LEN(elems) != 3)
     return FALSE;
-  return ary_include(mrb, RARRAY_PTR(elems), RARRAY_LEN(elems), val1) &&
-         ary_include(mrb, RARRAY_PTR(elems), RARRAY_LEN(elems), val2) &&
-         ary_include(mrb, RARRAY_PTR(elems), RARRAY_LEN(elems), val3) &&
-         ary_include(mrb, RARRAY_PTR(elems), RARRAY_LEN(elems), val4);
+  return ary_include_lat(mrb, elems, val1) &&
+         ary_include_lat(mrb, elems, val2) &&
+         ary_include_lat(mrb, elems, val3) &&
+         ary_include_lat(mrb, elems, val4);
 }
 
 static mrb_value

--- a/tools/hpcmrb/compile.c
+++ b/tools/hpcmrb/compile.c
@@ -160,9 +160,9 @@ lat_equal(mrb_state *mrb, mrb_value lat1, mrb_value lat2)
 static int
 lat_le(mrb_state *mrb, mrb_value lat1, mrb_value lat2)
 {
-  if (LAT(lat1)->type == LAT_UNKNOWN)
+  if (LAT_HAS_TYPE(mrb, lat1, LAT_UNKNOWN))
     return TRUE;
-  if (LAT(lat2)->type == LAT_DYNAMIC)
+  if (LAT_HAS_TYPE(mrb, lat2, LAT_DYNAMIC))
     return TRUE;
   if (!LAT_P(mrb, lat2)) {
     if (LAT_P(mrb, lat1))
@@ -205,9 +205,9 @@ lat_le(mrb_state *mrb, mrb_value lat1, mrb_value lat2)
 static int
 lat_set_add(mrb_state *mrb, mrb_value lat, mrb_value val)
 {
-  if (!LAT_P(mrb, lat) || LAT(lat)->type != LAT_SET)
+  if (!LAT_HAS_TYPE(mrb, lat, LAT_SET))
     NOT_REACHABLE();
-  if (LAT_P(mrb, val) && LAT(val)->type == LAT_SET)
+  if (LAT_HAS_TYPE(mrb, val, LAT_SET))
     NOT_REACHABLE();
   if (!LAT_P(mrb, val))
     val = mrb_obj_value(mrb_obj_class(mrb, val));

--- a/tools/hpcmrb/compile.c
+++ b/tools/hpcmrb/compile.c
@@ -104,13 +104,18 @@ ary_include_lat(mrb_state *mrb, mrb_value ary, mrb_value lat)
 static int
 lat_include(mrb_state *mrb, mrb_value lat, mrb_value val)
 {
-  if (LAT_P(mrb, lat))
-    return mrb_equal(mrb, lat, val);
-  if (LAT(lat)->type == LAT_DYNAMIC)
-    return TRUE;
-  if (LAT(lat)->type != LAT_SET)
-    return FALSE;
-  return ary_include_lat(mrb, LAT(lat)->elems, val);
+  switch (LAT_TYPE(mrb, lat)) {
+    case LAT_UNKNOWN:
+      return FALSE;
+    case LAT_SET:
+      return ary_include_lat(mrb, LAT(lat)->elems, val);
+    case LAT_CONST:
+      return mrb_equal(mrb, lat, val);
+    case LAT_DYNAMIC:
+      return TRUE;
+    default:
+      NOT_REACHABLE();
+  }
 }
 
 static int

--- a/tools/hpcmrb/compile.c
+++ b/tools/hpcmrb/compile.c
@@ -234,9 +234,7 @@ lat_set_equal1(mrb_state *mrb, mrb_value lat, mrb_value val)
 static int
 lat_set_equal2(mrb_state *mrb, mrb_value lat, mrb_value val1, mrb_value val2)
 {
-  if (!LAT_P(mrb, lat))
-    return FALSE;
-  if (LAT(lat)->type != LAT_SET)
+  if (!LAT_HAS_TYPE(mrb, lat, LAT_SET))
     return FALSE;
 
   mrb_value elems = LAT(lat)->elems;
@@ -250,9 +248,7 @@ static int
 lat_set_equal3(mrb_state *mrb, mrb_value lat, mrb_value val1, mrb_value val2,
                mrb_value val3)
 {
-  if (!LAT_P(mrb, lat))
-    return FALSE;
-  if (LAT(lat)->type != LAT_SET)
+  if (!LAT_HAS_TYPE(mrb, lat, LAT_SET))
     return FALSE;
 
   mrb_value elems = LAT(lat)->elems;
@@ -267,13 +263,11 @@ static int
 lat_set_equal4(mrb_state *mrb, mrb_value lat, mrb_value val1, mrb_value val2,
                mrb_value val3, mrb_value val4)
 {
-  if (!LAT_P(mrb, lat))
-    return FALSE;
-  if (LAT(lat)->type != LAT_SET)
+  if (!LAT_HAS_TYPE(mrb, lat, LAT_SET))
     return FALSE;
 
   mrb_value elems = LAT(lat)->elems;
-  if (RARRAY_LEN(elems) != 3)
+  if (RARRAY_LEN(elems) != 4)
     return FALSE;
   return ary_include_lat(mrb, elems, val1) &&
          ary_include_lat(mrb, elems, val2) &&

--- a/tools/hpcmrb/compile.c
+++ b/tools/hpcmrb/compile.c
@@ -26,7 +26,7 @@ struct lattice {
 
 static struct RClass *lat_class;
 #define LAT_P(mrb, obj) (mrb_obj_class(mrb, obj) == lat_class)
-#define LAT_CHECK_TYPE(mrb, obj, ty) (LAT_P(mrb, obj) && LAT(obj)->type == ty)
+#define LAT_HAS_TYPE(mrb, obj, ty) (LAT_P(mrb, obj) && LAT(obj)->type == ty)
 
 #define LAT_TYPE(mrb, obj)  (LAT_P(mrb, obj) ? LAT(obj)->type : LAT_CONST)
 
@@ -92,7 +92,7 @@ ary_include(mrb_state *mrb, mrb_value ary[], int len, mrb_value val)
 {
   int i;
   for (i = 0; i < len; i++) {
-    if (LAT_CHECK_TYPE(mrb, ary[i], LAT_DYNAMIC) || lat_equal(mrb, ary[i], val))
+    if (LAT_HAS_TYPE(mrb, ary[i], LAT_DYNAMIC) || lat_equal(mrb, ary[i], val))
       return TRUE;
   }
   return FALSE;

--- a/tools/hpcmrb/compile.c
+++ b/tools/hpcmrb/compile.c
@@ -360,18 +360,14 @@ lat_join(mrb_state *mrb, mrb_value val1, mrb_value val2)
           NOT_REACHABLE();
       }
     case LAT_SET:
-      switch (LAT_TYPE(mrb, val2)) {
-        case LAT_SET:
-          {
-            val1 = lat_clone(mrb, val1);
-            mrb_value *ary = RARRAY_PTR(LAT(val2)->elems);
-            int i, n = RARRAY_LEN(LAT(val2)->elems);
-            for (i = 0; i < n; i++)
-              lat_set_add(mrb, val1, ary[i]);
-            return val1;
-          }
-        default:
-          NOT_REACHABLE();
+      hpc_assert(LAT_HAS_TYPE(mrb, val2, LAT_SET));
+      {
+        mrb_value *ary = RARRAY_PTR(LAT(val2)->elems);
+        int i, len = RARRAY_LEN(LAT(val2)->elems);
+        val1 = lat_clone(mrb, val1);
+        for (i = 0; i < len; i++)
+          lat_set_add(mrb, val1, ary[i]);
+        return val1;
       }
     default:
       NOT_REACHABLE();

--- a/tools/hpcmrb/compile.c
+++ b/tools/hpcmrb/compile.c
@@ -8,7 +8,8 @@
 enum lat_type { /* Do no change this ordering */
   LAT_UNKNOWN,
   LAT_DYNAMIC,
-  LAT_CONST,    /* used for lat_join */
+  LAT_CONST,    /* any non-LAT object is classified as LAT_CONST
+                   used for lat_join */
   LAT_SET,
 };
 
@@ -78,6 +79,7 @@ lat_inspect(mrb_state *mrb, mrb_value lat)
         }
         return mrb_str_buf_cat(mrb, buf, "}", 1);
       }
+    /* LAT_CONST is not of Lattice class */
     default:
       break;
   }

--- a/tools/hpcmrb/compile.c
+++ b/tools/hpcmrb/compile.c
@@ -143,7 +143,6 @@ lat_equal(mrb_state *mrb, mrb_value lat1, mrb_value lat2)
         if (RARRAY_LEN(elems1) != RARRAY_LEN(elems2))
           return FALSE;
         mrb_value *ary1 = RARRAY_PTR(elems1);
-        mrb_value *ary2 = RARRAY_PTR(elems2);
         int i, len = RARRAY_LEN(elems1);
         for (i = 0; i < len; i++) {
           if (!ary_include_lat(mrb, elems2, ary1[i]))
@@ -183,11 +182,11 @@ lat_le(mrb_state *mrb, mrb_value lat1, mrb_value lat2)
       {
         mrb_value elems1 = LAT(lat1)->elems;
         mrb_value elems2 = LAT(lat2)->elems;
+        /* elems2 contains LAT_DYNAMIC */
         if (RARRAY_LEN(elems1) > RARRAY_LEN(elems2))
           return FALSE;
         mrb_value *ary1 = RARRAY_PTR(elems1);
-        mrb_value *ary2 = RARRAY_PTR(elems2);
-        int i, len1 = RARRAY_LEN(elems1), len2 = RARRAY_LEN(elems2);
+        int i, len1 = RARRAY_LEN(elems1);
         /* NB: We assume that len is small enough */
         for (i = 0; i < len1; i++) {
           if (!ary_include_lat(mrb, elems2, ary1[i]))

--- a/tools/hpcmrb/hpcmrb.h
+++ b/tools/hpcmrb/hpcmrb.h
@@ -11,6 +11,7 @@ extern "C" {
 
 #define NOT_IMPLEMENTED() mrb_bug("%s(%d): not implemented", __func__, __LINE__)
 #define NOT_REACHABLE()   mrb_bug("%s(%d): not reachable here", __func__, __LINE__)
+#define hpc_assert(cond)  do { if (!(cond)) { NOT_REACHABLE(); } } while(0)
 
 /* High-level intermediate representation. */
 enum hir_type {


### PR DESCRIPTION
LAT の部分のコードをよんで、わかりにくかった部分を直してみました。
いくつか数値や条件ミス的なバグもみつけたので、直しました。

直し方が気に入らない部分はご指摘いただければ、その部分をはずして投げなおします。

疑問におもったのが、 LAT_SET の要素として許されるものを Class intance に限定したほうがいいのではないでしょうか。
(class を send すると `Class` になるもの)

`ary_include_lat` (もとは `ary_include`) の

``` c
if (LAT_HAS_TYPE(mrb, ptr[i], LAT_DYNAMIC) || lat_equal(mrb, ptr[i], lat))
```

では `LAT_DYNMIC` が `LAT_SET` に含まれている事を考慮していますが、 lattice の定義上はこのような要素は存在しません。

仮に `LAT_DYNAMIC` が含まれるとなると、 `lat_le` で

``` c
        if (RARRAY_LEN(elems1) > RARRAY_LEN(elems2))
          return FALSE;
```

としているのも問題がでてきます(`elems2` が `LAT_DYNAMIC` を含んでいると `<=` が成立する)。

このあたりのアレコレを避けるために `lat_set_add` で追加するときに `!LAT_P(val)` を条件づけるというのはどうでしょう。

というのを考えていて今きがついたのですが、 `lat_join` の

``` c
        mrb_value *ary = RARRAY_PTR(LAT(val2)->elems);
        int i, len = RARRAY_LEN(LAT(val2)->elems);
        val1 = lat_clone(mrb, val1);
        for (i = 0; i < len; i++)
          lat_set_add(mrb, val1, ary[i]);
```

がまずいですね。

`lat_set_add` は non-lattice な object は class を取ってから追加するので、
一旦 `LAT_SET` の要素になったものをもういちど `lat_set_add` でかきこむと、ぜんぶ `Class` クラスになります。

``` c
{
  mrb_value str = mrb_str_new(mrb, "test1", 9);
  mrb_value fix = mrb_fixnum_value(6);
  mrb_value flo = mrb_float_value(6.0);

  mrb_value join1 = lat_join(mrb, str, fix);
  mrb_p(mrb, join1); // => {String, Fixnum}
  mrb_value join2 = lat_join(mrb, str, flo);
  mrb_p(mrb, join2); // => {String, Float}
  mrb_value join3 = lat_join(mrb, join1, join2);
  mrb_p(mrb, join3); // => {String, Fixnum, Class} -- {String, Fixnum, Float} とかになってほしい
}
```

`lat_set_add` の使用を調べたところ、いまの時点では上がイレギュラーなだけなので、
関数をふたつにわけ、それぞれに適当な名前をつけて、 `SET` 同士か否かで呼びわけるようにするのがいいでしょうか。

この方針でよければ、手直しはやります。
