### PR TITLE
move free func after object used

### DIFF
--- a/tools/hpcmrb/compile.c
+++ b/tools/hpcmrb/compile.c
@@ -1184,6 +1184,7 @@ hpc_compile_file(hpc_state *s, FILE *rfp, mrbc_context *c)
 
   mrb_state *mrb = s->mrb;  /* It is necessary for E_SYNTAX_ERROR macro */
   parser_state *p = mrb_parse_file(s->mrb, rfp, c);
+  HIR *ret;
 
   if (!p) return 0;
   if (!p->tree || p->nerr) {
@@ -1204,8 +1205,9 @@ hpc_compile_file(hpc_state *s, FILE *rfp, mrbc_context *c)
     }
   }
 
+  ret = compile(s, p->tree);
   mrb_parser_free(p);
-  return compile(s, p->tree);
+  return ret;
 }
 
 void


### PR DESCRIPTION
32bit環境で変な挙動をするのは、まだ使うオブジェクトのメモリを解法してしまっていたのが原因っぽかったです。
free呼び出しの位置を修正しましたので、大丈夫そうならマージお願いします。
